### PR TITLE
fix:default config missing internal tools

### DIFF
--- a/config/agents/default.agent.json
+++ b/config/agents/default.agent.json
@@ -19,8 +19,5 @@
   ],
   "interval": 30,
   "chat_id": "test",
-  "external_client" : [
-    "discord"
-  ],
-  "allowed_external_client_tools" : ["discord-send-messages"]
+  "allowed_internal_tools": ["get_balance", "get_own_balance", "swap_tokens"]
 }


### PR DESCRIPTION
The default configs are missing `"allowed_internal_tools"`. It was causing an error when trying to run the app locally.

Also, with the current external default configs it is required to have the discord the discord env vars set up. There may be a better way for accounting for this than removing them but this was the fix I found based on my little knowledge of the codebase.