### PR TITLE
chore(config): remove Discord from default configuration

### DIFF
--- a/config/agents/default.agent.json
+++ b/config/agents/default.agent.json
@@ -20,6 +20,6 @@
   "interval": 30,
   "chat_id": "test",
 
-  "external_plugins": ["discord"],
-  "internal_plugins": ["rpc"]
+  "external_plugins": [""],
+  "internal_plugins": ["rpc", "token"]
 }


### PR DESCRIPTION
Removed `discord_bot_token` in default setting.
Added "token" in `default.agent.json` to read token balance from wallet.